### PR TITLE
feature: readme, grouped conditionals, tests, minor refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,55 @@
-# php-salesforce-soql-builder
+# Salesforce SOQL Builder
+A SOQL builder for building queries for Salesforce.
+
+## Installation
+`composer require mihasicehcek/php_salesforce_soql_builder`
+
+## Features
+* Select
+* Conditionals (where)
+* Conditionals for date values
+* Grouped conditional statements
+* Where in
+* Where not in
+* Limit
+* Offset
+* Order By
+
+## Example usage
+
+```php
+$builder
+    ->select(['Id', 'Name', 'created_at'])
+    ->from('Account')
+    ->where('Name', '=', 'Test')
+    ->limit(20)
+    ->orderBy('created_at', 'DESC')
+    ->toSoql();
+```
+`> SELECT Id, Name, created_at FROM Account WHERE Name = 'Test' ORDER BY created_at DESC LIMIT 20` 
+```php
+$builder
+    ->select(['Id', 'Name'])
+    ->from('Account')
+    ->where('Name', '=', 'Test')
+    ->orWhere('Name', '=', 'Testing')
+    ->toSoql();
+```
+`> SELECT Id, Name FROM Account WHERE Name = 'Test' OR Name = 'Testing'`
+```php
+$builder
+    ->select(['Id', 'Name'])
+    ->from('Account')
+    ->startWhere()
+    ->where('Name', '=', 'Test')
+    ->where('Testing__c', '=', true)
+    ->endWhere()
+    ->orWhere('Email__c', '=', 'test@test.com')
+    ->toSoql(); 
+```
+`> SELECT Id, Name FROM Account WHERE (Name = 'Test' AND Testing__c = true) OR Email__c = 'test@test.com'`
+
+## Testing
+This library ships with phpunit.
+
+`phpunit` or `vendor/bin/phpunit`


### PR DESCRIPTION
# Feature: Readme, Grouped Conditionals
Sorry if this is going into a stale library. I'd like to include this as part of a package im working on and it was missing a few little things that I wanted to add so I figured I would PR it. 

* Adds readme with example usage
* Adds ability to group conditional expressions with `startWhere`, `endWhere`. It's not exactly elegant, but it appears to be functioning correctly with tests passing.
* Refactors `gettype` calls to use `is_{type}` calls
* Hoists nested conditionals up
* Adds tests for grouped conditional expressions
* Adds missing tests for exceptions
* No breaking changes \ All previous tests passing without issue